### PR TITLE
Chore 162770662 switch to warning

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -158,11 +158,11 @@ describe('index', function() {
     });
 
     function makeReq(props) {
-      return Object.assign({}, {url: 'http://example.com/path', path: '/path'}, props)
+      return Object.assign({url: 'http://example.com/path', path: '/path'}, props)
     }
 
     function makeRes(props) {
-      return Object.assign({}, {locals: {}, statusCode: 200, end: ()=>{}}, props)
+      return Object.assign({locals: {}, statusCode: 200, end: () => {}}, props)
     }
 
     it('should patch res.end and emit an info log instance for a 200 response', function(done) {

--- a/winex.js
+++ b/winex.js
@@ -189,7 +189,7 @@ factory = function(winstonLogger, classMeta, opts) {
           }
           level = "info";
           if ((400 <= (_ref = res.statusCode) && _ref < 500)) {
-            level = "warn";
+            level = "warning";
           }
           if (res.statusCode >= 500) {
             level = "error";


### PR DESCRIPTION
@ahaurw01 

In https://github.com/spanishdict/pn-logging/pull/19 I incorporated the latest version of winex, which used `warn`, a change from v0.0.6, which is what pn-logging was pinned to -- it used `warning`.

This PR adds middleware logging tests which would have caught this, and switches to `warning`. 

Because pn-logging has always used `warning`, any repo that consumes it should be good.

Because winex used `warning` then switched to `warn`, the repos that use it (fluencia and cicero) need to be checked for calls to `warn` if they are switched over to pn-logging.

Atalanta, which has its own internal logging module (a prototype of winex), uses `warning`.

Neodarwin, which uses an internal fork of an old version of winex, uses `warn`.

### How to test

```
# in pn-logging
yarn link

# in sd-playground
yarn link pn-logging
```

Then make requests to sd-playground that generate 200, 400, and 500 responses, and observe that the correct logs are emitted, and no errors are thrown. (On master, a 400 response will cause a TypeError.)