### PR TITLE
Feature 163129410 dont log status code as number

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -180,6 +180,13 @@ describe('index', function() {
         const infoStub = sinon.stub(res.locals._log, 'info')
         res.end()
         sinon.assert.calledOnce(infoStub)
+        sinon.assert.calledWithExactly(infoStub, 'request')
+        const logObj = res.locals._log
+        expect(logObj).to.have.property('meta')
+        expect(logObj.meta).to.eql( { reqPath: '/path',
+                                      reqQuery: '',
+                                      reqQueryChars: 0,
+                                      resStatus: 200 })
         done()
       })
     });
@@ -199,6 +206,12 @@ describe('index', function() {
         const warningStub = sinon.stub(res.locals._log, 'warning')
         res.end()
         sinon.assert.calledOnce(warningStub)
+        const logObj = res.locals._log
+        expect(logObj).to.have.property('meta')
+        expect(logObj.meta).to.eql( { reqPath: '/path',
+                                      reqQuery: '',
+                                      reqQueryChars: 0,
+                                      resStatus: 400 })
         done()
       })
     });
@@ -218,10 +231,15 @@ describe('index', function() {
         const errorStub = sinon.stub(res.locals._log, 'error')
         res.end()
         sinon.assert.calledOnce(errorStub)
+        const logObj = res.locals._log
+        expect(logObj.meta).to.eql( { reqPath: '/path',
+                                      reqQuery: '',
+                                      reqQueryChars: 0,
+                                      resStatus: 500 })
         done()
       })
-    })    
-    
+    })
+
   });
 
   describe('_getSentryMeta', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ describe('index', function() {
         expect(logObj.meta).to.eql( { reqPath: '/path',
                                       reqQuery: '',
                                       reqQueryChars: 0,
-                                      resStatus: 200 })
+                                      resStatus: '200' })
         done()
       })
     });
@@ -211,7 +211,7 @@ describe('index', function() {
         expect(logObj.meta).to.eql( { reqPath: '/path',
                                       reqQuery: '',
                                       reqQueryChars: 0,
-                                      resStatus: 400 })
+                                      resStatus: '400' })
         done()
       })
     });
@@ -235,7 +235,7 @@ describe('index', function() {
         expect(logObj.meta).to.eql( { reqPath: '/path',
                                       reqQuery: '',
                                       reqQueryChars: 0,
-                                      resStatus: 500 })
+                                      resStatus: '500' })
         done()
       })
     })

--- a/winex.js
+++ b/winex.js
@@ -237,7 +237,7 @@ factory = function(winstonLogger, classMeta, opts) {
         res = {};
       }
       return this.meta = extend(this.meta, {
-        resStatus: res.statusCode
+        resStatus: res.statusCode.toString()
       });
     };
 


### PR DESCRIPTION
@ahaurw01 

Quick improvement -- this will be useful when reviewing logs in Loggly, because it doesn't segment on numbers.