### PR TITLE
Chore remove raven

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,6 @@ pairs on its `meta` property. `addError` is a helper method that takes an
 (Errors within a req/res lifecycle may also warrant their own ad-hoc log
 messages, such as if an API request to a service fails.)
 
-### Report to [Sentry](https://getsentry.com)
-
-If error object is passed to logger's logging methods, e.g. `error`, in addition to sending data to defined transporter (most likely Loggly), the error will also be sent to Sentry.
-
-```js
-var Log = require('pn-logging').Log;
-var logger = new Log(config);
-
-logger.error('Error message', {
-  tags: {key: 'value'}
-}, err);
-```
-
-Refer to [sentry docs](https://docs.getsentry.com/hosted/clients/node/usage/#optional-attributes).
-
-`tags`, `fingerprint`, and `level` properties of log meta object will be mapped to related sentry optional attributes. All other meta properties will become `extra` property in sentry optional attributes.
-
 ### Config
 
 The `config` object passed to `Log` constructor should look like:
@@ -91,11 +74,5 @@ var config = {
       }
     }
   ],
-  sentry: {
-    // specify `false` here to disable sentry
-    dsn: 'https://*****@app.getsentry.com/xxxxx',
-    // pass directly to raven constructor refer to https://goo.gl/9Ud7Mz
-    options: {}
-  }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 var util = require('util');
 var winston = require('winston');
 var winex = require('./winex');
-var isobject = require('isobject')
 
 var sysLogLevels;
 
@@ -98,6 +97,11 @@ function Log(options) {
   this.middleware = this._winexConstructor.middleware;
 }
 
+// https://github.com/jonschlinkert/isobject/blob/master/index.js
+function isObject(val) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
 /**
  * Helper function for attaching methods to the logger prototype.
  *
@@ -107,7 +111,7 @@ function Log(options) {
  */
 function _logger(level) {
   return function(message, meta, error, req, res) {
-    if (isobject(message)) {
+    if (isObject(message)) {
       meta = meta ? Object.assign(meta, message.meta) : message.meta;
       error = error ? error : message.error;
       req = req ? req : message.req;

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "dependencies": {
     "deep-extend": "0.2.2",
     "isobject": "3.0.1",
-    "lodash": "4.17.11",
-    "raven": "0.9.0",
     "winston": "2.4.5",
     "winston-loggly": "1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pn-logging",
-  "version": "5.3.1",
+  "version": "6.0.0",
   "description": "A logging wrapper around winston and sentry.",
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "homepage": "https://github.com/spanishdict/pn-logging",
   "dependencies": {
     "deep-extend": "0.2.2",
-    "isobject": "3.0.1",
     "winston": "2.4.5",
     "winston-loggly": "1.3.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('index', function() {
 
   describe('Log constructor', function() {
     it('should return a Log instance', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.be.an.instanceOf(index.Log);
     });
@@ -34,49 +34,49 @@ describe('index', function() {
     });
 
     it('should have a debug method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('debug');
     });
 
     it('should have a info method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('info');
     });
 
     it('should have a notice method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('notice');
     });
 
     it('should have a warning method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('warning');
     });
 
     it('should have a error method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('error');
     });
 
     it('should have a crit method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('crit');
     });
 
     it('should have a alert method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('alert');
     });
 
     it('should have a emerg method', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.respondTo('emerg');
     });
@@ -106,7 +106,6 @@ describe('index', function() {
             },
           },
         ],
-        sentry: {},
         meta: {
           type: 'server',
           key1: 'value1',
@@ -145,7 +144,6 @@ describe('index', function() {
             },
           },
         ],
-        sentry: {},
       });
     });
 
@@ -300,12 +298,12 @@ describe('index', function() {
     }
 
     it('should be lending its middleware handler to pn-logging Log class', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       expect(log.middleware).to.equal(log._winexConstructor.middleware);
     });
 
     it('should allow adding to meta via several methods', () => {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       const WinexLog = log._winexConstructor;
       const winexLog = new WinexLog();
 
@@ -358,14 +356,14 @@ describe('index', function() {
 
   describe('middleware', function() {
     it('should have middleware on the instance', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
 
       expect(log).to.have.property('middleware');
       expect(log.middleware).to.be.a('function');
     });
 
     it('should produce a middleware function', function() {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware();
 
       expect(middleware).to.be.a('function');
@@ -384,7 +382,7 @@ describe('index', function() {
     }
 
     it('should patch res.end and emit an info log instance for a 200 response', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware();
 
       var req = makeReq();
@@ -412,7 +410,7 @@ describe('index', function() {
     });
 
     it('should patch res.end and emit a warning log instance for a 400 response', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware();
 
       var req = makeReq();
@@ -439,7 +437,7 @@ describe('index', function() {
     });
 
     it('should patch res.end and emit a warning log instance for a 404 response', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware();
 
       var req = makeReq();
@@ -466,7 +464,7 @@ describe('index', function() {
     });
 
     it('should patch res.end and emit an info log instance for a 404 response with info404 option', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware({ info404: true });
 
       var req = makeReq();
@@ -495,7 +493,7 @@ describe('index', function() {
     });
 
     it('should patch res.end and emit an error log instance for a 500 response', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware();
 
       var req = makeReq();
@@ -521,7 +519,7 @@ describe('index', function() {
     });
 
     it('should allow overriding the level with log.level', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware({ info404: true });
 
       var req = makeReq();
@@ -550,7 +548,7 @@ describe('index', function() {
     });
 
     it('should correctly count multibyte characters in url query', function(done) {
-      var log = new index.Log({ transports: [], sentry: {} });
+      var log = new index.Log({ transports: [] });
       var middleware = log.middleware({ info404: true });
 
       var req = makeReq({ url: 'http://smi.li/?q=💩' });
@@ -574,143 +572,6 @@ describe('index', function() {
           resStatus: '200',
         });
         done();
-      });
-    });
-  });
-
-  describe('_getSentryMeta', function() {
-    it('should return just tags if meta is not defined', function() {
-      var result = index._getSentryMeta();
-
-      expect(result).to.deep.equal({
-        extra: {},
-        tags: {
-          env: 'test',
-        },
-        fingerprint: undefined,
-        level: undefined,
-      });
-    });
-
-    it('should add tags property', function() {
-      var input = {
-        tags: {
-          key1: 'value1',
-          key2: 'value2',
-        },
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('tags');
-      expect(result.tags).to.have.property('key1', 'value1');
-      expect(result.tags).to.have.property('key2', 'value2');
-    });
-
-    it('should add fingerprint property', function() {
-      var input = {
-        fingerprint: 'fingerprintValue',
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('fingerprint', 'fingerprintValue');
-    });
-
-    it('should add level property', function() {
-      var input = {
-        level: 'error',
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('level', 'error');
-    });
-
-    it('should exclude tags, fingerprint, and level in extra', function() {
-      var input = {
-        level: 'error',
-        tags: 'tagsValue',
-        fingerprint: 'fingerprintValue',
-        key1: 'value1',
-        key2: 'value2',
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('extra');
-      expect(result.extra).to.not.have.property('level');
-      expect(result.extra).to.not.have.property('tags');
-      expect(result.extra).to.not.have.property('fingerprint');
-    });
-
-    it('should include other property in extra', function() {
-      var input = {
-        level: 'error',
-        tags: 'tagsValue',
-        fingerprint: 'fingerprintValue',
-        key1: 'value1',
-        key2: 'value2',
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('extra');
-      expect(result.extra).to.have.property('key1', 'value1');
-      expect(result.extra).to.have.property('key2', 'value2');
-    });
-
-    it('should add tags if no tags are defined', function() {
-      var input = {};
-
-      var result = index._getSentryMeta(input);
-
-      expect(result).to.have.property('extra');
-      expect(result.tags).to.have.property('env', 'test');
-    });
-
-    it('should add env to tags if no env is defined', function() {
-      var input = {
-        tags: {
-          key1: 'value1',
-          key2: 'value2',
-        },
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result.tags).to.have.property('env', 'test');
-    });
-
-    it('should not change env in tags if env is defined', function() {
-      var input = {
-        tags: {
-          key1: 'value1',
-          key2: 'value2',
-          env: 'production',
-        },
-      };
-
-      var result = index._getSentryMeta(input);
-
-      expect(result.tags).to.have.property('env', 'production');
-    });
-
-    it('should not mutate input', function() {
-      var input = {
-        tags: {
-          key1: 'value1',
-          key2: 'value2',
-        },
-      };
-
-      index._getSentryMeta(input);
-
-      expect(input).to.eql({
-        tags: {
-          key1: 'value1',
-          key2: 'value2',
-        },
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,11 +419,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-cookie@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.1.0.tgz#90eb469ddce905c866de687efc43131d8801f9d0"
-  integrity sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=
-
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1406,17 +1401,17 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isobject@3.0.1, isobject@^3.0.0, isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
@@ -1551,7 +1546,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.11:
+lodash@^4.17.10, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -1576,11 +1571,6 @@ lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
   integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
-
-lsmod@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-0.0.3.tgz#17e13d4e1ae91750ea5653548cd89e7147ad0244"
-  integrity sha1-F+E9ThrpF1DqVlNUjNiecUetAkQ=
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -1761,7 +1751,7 @@ node-environment-flags@1.0.4:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-node-uuid@~1.4.1, node-uuid@~1.4.7:
+node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
   integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
@@ -2014,16 +2004,6 @@ qs@~6.2.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
   integrity sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=
-
-raven@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-0.9.0.tgz#f2486e6dc1eb6f3ebf40486040f331effc5c488d"
-  integrity sha1-8khubcHrbz6/QEhgQPMx7/xcSI0=
-  dependencies:
-    cookie "0.1.0"
-    lsmod "~0.0.3"
-    node-uuid "~1.4.1"
-    stack-trace "0.0.7"
 
 readable-stream@~2.0.5:
   version "2.0.6"
@@ -2338,11 +2318,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-stack-trace@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.7.tgz#c72e089744fc3659f508cdce3621af5634ec0fff"
-  integrity sha1-xy4Il0T8Nln1CM3ONiGvVjTsD/8=
 
 stack-trace@0.0.x:
   version "0.0.10"


### PR DESCRIPTION
@mkalish @iraquint 

Removes raven used for sentry by pubnation. We don't need this anymore. Lodash was only used by that as well. isObject was a one liner. 

Was added in https://github.com/spanishdict/pn-logging/pull/7

Tested in atalanta https://github.com/spanishdict/atalanta/pull/928