### PR TITLE
add object.assign to make it extensible

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function Log(options) {
   } else {
     logTransports = options.transports.map(function(t) {
       var cls = Object.keys(t)[0];
-      var opts = t[cls];
+      var opts = Object.assign({},t[cls]);
       var Transport = winston.transports[cls];
       if(Transport == winston.transports.Console){
         var format = setupConsoleFormatters(opts);


### PR DESCRIPTION
## What
I had to use Object.assign for the opts object because I was getting the error `TypeError: can't define property "x": "obj" is not extensible` when I pulled it in to po-intake. 

### Test
1. In po-intake, set the package.json file to use the hash of this branch `70e0cecf35aba5715fc7790832b8dd10e7d84cdd` for pn-logging.
2. Run yarn
3. Rebuild po-intake and run it
4. Ensure the service starts and the console logging is working