### PR TITLE
add default transport when none are provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,14 @@ function Log(options) {
 
   if (options.rawTransports){
     logTransports = options.transports
-  } else {
+  }
+  else if(options.transports.length == 0){
+    //defaults to console if no transports are given
+    logTransports = new winston.transports.Console({
+        format: winston.format.simple()
+      });
+  }
+  else {
     logTransports = options.transports.map(function(t) {
       var cls = Object.keys(t)[0];
       var opts = Object.assign({},t[cls]);

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function Log(options) {
   else if(options.transports.length == 0){
     //defaults to console if no transports are given
     logTransports = new winston.transports.Console({
-        format: winston.format.simple()
+        format: winston.format.json()
       });
   }
   else {

--- a/test/index.js
+++ b/test/index.js
@@ -146,6 +146,15 @@ describe('index', function() {
         ],
       });
     });
+    
+    it('should default transport to console when none are provided', function(){
+      sandbox.restore();
+      let stub = sandbox.stub(console, 'error');
+      log = new index.Log({transports: []});
+      log.debug('i should not throw an error');
+
+      sinon.assert.neverCalledWith(stub);
+    });
 
     it('should log a message', function() {
       log.debug('say what?');


### PR DESCRIPTION
@sandinmyjoints 
### What
When upgrading pn-logging in sd-examples we found that an error was thrown for our test config. https://github.com/spanishdict/neodarwin/pull/11039 && https://github.com/spanishdict/sd-examples/pull/64

This adds a console log as the default transporter when it is left empty by the config.

### Test
Upgrade sd-examples to use pn-logginig with this SHA and run tests. Ensure there are no errors.