### PR TITLE
Chore: create ambient type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+declare module "pn-logging" {
+  type sysLogLevels =
+    | "emerg"
+    | "alert"
+    | "crit"
+    | "error"
+    | "warning"
+    | "notice"
+    | "info"
+    | "debug";
+
+  type LoggingParameters = Parameters<
+    (
+      message: string,
+      meta: object,
+      err?: unknown,
+      req?: Express.Request,
+      res?: Express.Request
+    ) => void
+  >;
+
+  type ILog = {
+    [Action in sysLogLevels]: (...args: LoggingParameters) => void;
+  };
+
+  export class Log implements ILog {
+    constructor(options: unknown);
+    emerg(...args: LoggingParameters): void;
+    alert(...args: LoggingParameters): void;
+    crit(...args: LoggingParameters): void;
+    error(...args: LoggingParameters): void;
+    warning(...args: LoggingParameters): void;
+    notice(...args: LoggingParameters): void;
+    info(...args: LoggingParameters): void;
+    debug(...args: LoggingParameters): void;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=10"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/spanishdict/pn-logging.git"
@@ -20,6 +21,7 @@
     "winston-loggly-bulk": "3.2.1"
   },
   "devDependencies": {
+    "@types/express": "4.17.13",
     "chai": "4.2.0",
     "eslint": "7.10.0",
     "istanbul": "0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/body-parser@npm:*":
+  version: 1.19.2
+  resolution: "@types/body-parser@npm:1.19.2"
+  dependencies:
+    "@types/connect": "*"
+    "@types/node": "*"
+  checksum: bd4e6dc17c8d5d83a84717a4af276dfab351ca7a09b6b4d29d35ae3c01e29f9c88f28dcec194943a9cec4690568fb42470d8af06097cd0dcd85ee3d32ea6a9fd
+  languageName: node
+  linkType: hard
+
+"@types/connect@npm:*":
+  version: 3.4.35
+  resolution: "@types/connect@npm:3.4.35"
+  dependencies:
+    "@types/node": "*"
+  checksum: 4b04cae4bc8e0d0637240b0303e5e6c5a081f85873bb338a02dae95bdfcad5c178be03e41d47f8194675cea0c67ffbfce1530b6633040b908d20139745cb338f
+  languageName: node
+  linkType: hard
+
+"@types/express-serve-static-core@npm:^4.17.18":
+  version: 4.17.28
+  resolution: "@types/express-serve-static-core@npm:4.17.28"
+  dependencies:
+    "@types/node": "*"
+    "@types/qs": "*"
+    "@types/range-parser": "*"
+  checksum: cd8873b603f4a9cf370947808d78dd1353d41069bd442d54e4cdcb36402221d9e7fc73ab6e5eff1b4af8037ea065d916ef9bfe3d7ac3f57872d201cdf6d3b387
+  languageName: node
+  linkType: hard
+
+"@types/express@npm:4.17.13":
+  version: 4.17.13
+  resolution: "@types/express@npm:4.17.13"
+  dependencies:
+    "@types/body-parser": "*"
+    "@types/express-serve-static-core": ^4.17.18
+    "@types/qs": "*"
+    "@types/serve-static": "*"
+  checksum: 9f17da703df21e3f1cee2fe1864b9fcac2ab07c37382b972a194a3a484b41c1fbe4022b6cfe546f0171fd2d93b324dd3839512494f4cba639c2afa021e6dbb12
+  languageName: node
+  linkType: hard
+
+"@types/mime@npm:^1":
+  version: 1.3.2
+  resolution: "@types/mime@npm:1.3.2"
+  checksum: c354bc135628c2f4ab64801ca3867c3acbd4050611579c4c9f5bdfecfb70db71bb8540bf8611b4319f5ef44139c5f7c5af81254369add5ed59e7e02ce929b96f
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:*":
+  version: 17.0.10
+  resolution: "@types/node@npm:17.0.10"
+  checksum: 3d6f59adb8a5d5770590c23ec2ac97ab91a3fbb47696e60c01fcee87d330d9360fe500fd963c54b01668d75c668d44a0a996fb89b7997c2530545465676e3671
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:*":
+  version: 6.9.7
+  resolution: "@types/qs@npm:6.9.7"
+  checksum: ee2cd0bd1eda38bcf868bb1aebb99401eb05641fff29f910c1c8316718e4d3b26c403594a62d694145684643a5d2e4dfc4b9860630c412651d37ff97571de8b0
+  languageName: node
+  linkType: hard
+
+"@types/range-parser@npm:*":
+  version: 1.2.4
+  resolution: "@types/range-parser@npm:1.2.4"
+  checksum: 5c1bd5062116957837a5315c442422889eb2dc1eb5cc926e4ac788926b7c28363b0bf7564e36691108b7da8f7615826f9ac5bbe995b225d17b2a5cb998d69da9
+  languageName: node
+  linkType: hard
+
+"@types/serve-static@npm:*":
+  version: 1.13.10
+  resolution: "@types/serve-static@npm:1.13.10"
+  dependencies:
+    "@types/mime": ^1
+    "@types/node": "*"
+  checksum: 3ee9adfd05f8b2af942e26afe9ff3993e723e1af70718aa8c2b1c0f72fe5f45be69ac20aa7ee5859d1c18f2397d5fcf4eafcb30890d88e6836a98aa7a3adb6c3
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
@@ -2623,6 +2703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pn-logging@workspace:."
   dependencies:
+    "@types/express": 4.17.13
     chai: 4.2.0
     eslint: 7.10.0
     istanbul: 0.4.5


### PR DESCRIPTION
@vincecampanale 
This adds ambient type definitions for pn-logging.

# Testing
I tested it by linking pn-logging locally to sd-playground and running `tsc` which you can do as well if you'd like though I think it's fine if you prefer to just read the code.