### PR TITLE
Loggly will throw connection errors at times. Instead of throwing an …

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ sysLogLevels = {
 
 /**
  * setups up formatters for winston 3 format (https://github.com/winstonjs/winston#formats)
- * @param {*} formatter options 
- * @returns 
+ * @param {*} formatter options
+ * @returns
  */
 function setupConsoleFormatters(options) {
   var formatters = [];
@@ -172,7 +172,11 @@ function _logger(level) {
       log.addError(error);
     }
 
-    log[level](message);
+    try {
+      log[level](message);
+    } catch (error) {
+      console.error("pn-logging", error.message);
+    }
   };
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var winston = require('winston');
 var TestTransport = require('./mock/test-transport');
+var BadConnectionTransport = require('./mock/bad-connection-transport');
 var index = require('../index');
 
 describe('index', function() {
@@ -161,6 +162,33 @@ describe('index', function() {
       expect(metaArgs.key1).to.equal('value1');
       expect(metaArgs.key3).to.equal('value3');
       expect(metaArgs).not.to.have.property('key2')
+    });
+  });
+
+  describe('bad connection', function() {
+    var log;
+
+    beforeEach(function() {
+      sandbox.stub(winston, 'transports', { BadConnectionTransport: BadConnectionTransport });
+
+      log = new index.Log({
+        transports: [
+          {
+            BadConnectionTransport: {
+              level: 'debug',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should not throw an error, but instead console.error', function() {
+      let stub = sandbox.stub(console, 'error');
+
+      log.debug('say what?');
+
+      sinon.assert.calledOnce(stub);
+      sinon.assert.calledWith(stub, 'pn-logging', 'connection failed');
     });
   });
 

--- a/test/mock/bad-connection-transport.js
+++ b/test/mock/bad-connection-transport.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var util = require('util');
+var Transport = require('winston-transport');
+
+/**
+ * Transporter
+ *
+ * @constructor
+ * @param {object}   opts       Options
+ * @param {string}   opts.level Log level
+ * @param {function} opts.__log Callback to run when logging
+ */
+function BadConnectionTransport(opts) {
+  this.name = 'test';
+  this.level = opts.level;
+  this.__log = opts.__log;
+}
+
+util.inherits(BadConnectionTransport, Transport);
+
+// eslint-disable-next-line no-unused-vars
+BadConnectionTransport.prototype.log = function (level, msg, meta, callback) {
+  throw new Error("connection failed");
+};
+
+module.exports = BadConnectionTransport;


### PR DESCRIPTION
…unhandled error, ignore it.